### PR TITLE
#102 perf: axios instance token access, refresh, error catch

### DIFF
--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,7 +1,70 @@
-import axios, { AxiosInstance } from "axios";
+//테스트 방법: web콘솔창에 localStorage.setItem("accessToken", "테스트용_JWT_토큰"); 입력 후 원하는 페이지로 이동
 
+import axios, {
+  AxiosInstance,
+  AxiosError,
+  InternalAxiosRequestConfig,
+} from "axios";
+
+// API 응답 타입 정의
+interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+// Axios 인스턴스 생성
+// await.get/post/patch시 자동으로 토큰 요청 전송
 const instance: AxiosInstance = axios.create({
   baseURL: "https://winereview-api.vercel.app/12-2/",
 });
+
+// 요청 인터셉터: 자동으로 토큰 추가
+instance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem("accessToken"); // 로컬 스토리지에서 토큰 가져오기
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`; // Authorization 헤더에 토큰이 담김
+    }
+    return config;
+  },
+  (error: AxiosError) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401 발생 시 토큰 갱신 처리
+instance.interceptors.response.use(
+  (response) => response, // 정상적인 리스폰스시 처리
+  async (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      // 에러(만료 코드 401)시 리프레시 토큰 활용
+      try {
+        const refreshToken = localStorage.getItem("refreshToken");
+        if (!refreshToken) throw new Error("No refresh token available"); // 리프레시 토큰이 없을 경우 에러 메세지
+
+        // 리프레시 토큰으로 새 토큰 요청
+        const { data } = await axios.post<RefreshResponse>(
+          "https://winereview-api.vercel.app/auth/refresh",
+          { refreshToken }
+        );
+
+        // 받아온 새로운 토큰 저장
+        localStorage.setItem("accessToken", data.accessToken);
+
+        // 원래 요청 다시 보내기
+        // interceptors.request.use는 재사용 불가. 새로운 코드 작성.
+        if (error.config) {
+          // error.config : 에러를 반환한 요청의 데이터 값
+          error.config.headers.Authorization = `Bearer ${data.accessToken}`;
+          return axios(error.config);
+        }
+      } catch (refreshError) {
+        console.error("토큰 갱신 실패:", refreshError);
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        window.location.href = "/login"; // 로그인 페이지로 이동
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default instance;

--- a/src/pages/myprofile/components/ProfileCard.tsx
+++ b/src/pages/myprofile/components/ProfileCard.tsx
@@ -1,32 +1,26 @@
 import React, { useEffect, useState } from "react";
 import styles from "./ProfileCard.module.css";
 import SecondaryButton from "@/components/SecondaryButton";
-import axios from "@/libs/axios";
+import axios from "@/libs/axios"; //토큰관리
 import ProfileUpdateModal from "./ProfileUpdateModal";
 
 const ProfileCard: React.FC = () => {
   const [user, setUser] = useState<{
     nickname: string;
-    email: string;
     image: string;
   } | null>(null);
 
   const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  // 사용자 정보 불러오기
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        const response = await axios.get("/users/me", {
-          headers: {
-            Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NjQ4LCJ0ZWFtSWQiOiIxMi0yIiwic2NvcGUiOiJhY2Nlc3MiLCJpYXQiOjE3Mzg5MTYyODYsImV4cCI6MTczODkxODA4NiwiaXNzIjoic3AtZXBpZ3JhbSJ9.d2EOTKxZKsapUfSioriHwNnodiPT6U946wU5uJoBl3c`,
-          },
-        });
-
+        const response = await axios.get("/users/me"); // 토큰 받아옴
         const data = response.data;
         setUser({
           nickname: data.nickname || "이름 없음",
-          email: data.email || "이메일 없음",
           image: data.image || "/assets/icon/defaultProfile.png",
         });
       } catch (error) {
@@ -59,10 +53,8 @@ const ProfileCard: React.FC = () => {
           alt="프로필 사진"
           className={styles.profile_image}
         />
-
         <div className={styles.profile_text}>
           <h2 className={styles.profile_name}>{user?.nickname}</h2>
-          <p className={styles.profile_email}>{user?.email}</p>
         </div>
       </div>
 


### PR DESCRIPTION
토큰을 직접 받던 하드코딩된 부분을

```
const response = await axios.get("/users/me", {
          headers: {
            Authorization: `Bearer <토큰>`,
          },
        });
```
를
`const response = await axios.get("앤드포인트 주소");`

로 변경 후,

실행된 웹 화면 console 창에 `localStorage.setItem("accessToken", "테스트용_JWT_토큰"); `입력 후 원하는 페이지로 이동

하여 사용 가능합니당