### PR TITLE
feat: 페이지네이션을 통한 와인데이터 불러오기 기능 구현 및 이미지와 텍스트 UI, UX 디자인 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,19 +14,25 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
-        hostname: "upload.wikimedia.org", // 외부 이미지 URL 허용
+        hostname: "upload.wikimedia.org",
       },
       {
         protocol: "https",
-        hostname: "newneek.co", // 오류 발생한 도메인 추가
+        hostname: "newneek.co",
       },
       {
         protocol: "https",
-        hostname: "d2phebdq64jyfk.cloudfront.net", // 추가적으로 필요한 도메인
+        hostname: "d2phebdq64jyfk.cloudfront.net",
       },
       {
         protocol: "https",
-        hostname: "via.placeholder.com", // Placeholder 이미지 도메인 추가
+        hostname: "via.placeholder.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "img.khan.co.kr",  // 추가된 이미지 호스트
+        pathname: "/**",  // 모든 경로 허용
       },
     ],
   },

--- a/src/pages/wines/indexcomponents/MonthlyWineCarousel.module.css
+++ b/src/pages/wines/indexcomponents/MonthlyWineCarousel.module.css
@@ -4,7 +4,7 @@
   border-radius: 16px;
   width: 100%;
   max-width: 1140px;
-  margin: 20px auto; /* 헤더와 20px 간격 */
+  margin: 20px auto;
   padding: 30px;
   position: relative;
 }
@@ -36,8 +36,9 @@
   border-radius: 12px;
   padding: 15px;
   display: flex;
-  gap: 28px;
+  gap: 20px;
   align-items: flex-start;
+  overflow: hidden;
 }
 
 /* 와인 이미지 */
@@ -53,26 +54,84 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 5px;
+  width: 100%;
 }
 
+/* 평점 스타일 */
 .wine_rating {
-  font-family: 'Pretendard', sans-serif;
+  width: 57px;
+  height: 43px;
+  font-family: 'Pretendard';
+  font-style: normal;
   font-weight: 800;
   font-size: 36px;
+  line-height: 43px;
   color: #2D3034;
-  margin: 0;
+  flex: none;
+  order: 0;
+  flex-grow: 0;
 }
 
-.wine_name, .wine_type {
-  font-family: 'Pretendard', sans-serif;
-  font-weight: 400;
+/* 별점 컨테이너 */
+.stars {
+  display: flex;
+  gap: 2px;
+  width: 90px;
+  height: 18px;
+}
+
+/* 채워진 별 */
+.star_filled {
+  color: #6A42DB;  /* 보라색 별 색상 */
+  border-radius: 4px;  /* 별 모서리 둥글게 */
+  padding: 2px;  /* 별 내부 여백 */
+}
+
+/* 빈 별 */
+.star_empty {
+  color: #CFDBEA;
+  border-radius: 4px;
+  padding: 2px;
+}
+
+/* 와인 이름 및 타입 */
+.wine_details {
+  max-height: 70px;
+  overflow-y: auto;
+  width: 100%;
+  word-break: break-word;
+}
+
+.name {
+  font-size: 14px;
+  font-weight: bold;
+  color: #9FACBD;
+  margin: 0;
+  white-space: normal;
+  line-height: 1.4;
+}
+
+.wine_type {
   font-size: 12px;
-  line-height: 18px;
   color: #9FACBD;
   margin: 0;
 }
 
-/* 화살표 버튼 공통 스타일 */
+/* 스크롤바 스타일 */
+.wine_details::-webkit-scrollbar {
+  width: 4px;
+}
+
+.wine_details::-webkit-scrollbar-thumb {
+  background-color: #6A42DB;
+  border-radius: 4px;
+}
+
+.wine_details::-webkit-scrollbar-track {
+  background-color: #E0E0E0;
+}
+
+/* 화살표 버튼 */
 .arrow_button_left, .arrow_button_right {
   position: absolute;
   width: 48px;
@@ -98,17 +157,17 @@
   right: 20px;
 }
 
-/* 화살표 아이콘 */
 .arrow_icon {
   width: 24px;
   height: 24px;
   color: #9FACBD;
 }
 
-/* 메인 컨텐츠 가운데 정렬 */
-.main_content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+/* 메시지 스타일 */
+.no_wines_message {
+  font-size: 14px;
+  color: #9FACBD;
+  text-align: center;
   width: 100%;
-} 
+  margin: 20px 0;
+}

--- a/src/pages/wines/indexcomponents/MonthlyWineCarousel.tsx
+++ b/src/pages/wines/indexcomponents/MonthlyWineCarousel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "@/libs/axios";
 import styles from "./MonthlyWineCarousel.module.css";
-import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
+import { FaArrowLeft, FaArrowRight, FaStar } from "react-icons/fa";
 
 interface Wine {
   id: number;
@@ -25,7 +25,8 @@ const MonthlyWineCarousel: React.FC = () => {
     const fetchMonthlyWines = async () => {
       try {
         const response = await axios.get("wines?limit=10");
-        setMonthlyWines(response.data.list);
+        const shuffledWines = response.data.list.sort(() => Math.random() - 0.5);  // 배열 셔플
+        setMonthlyWines(shuffledWines);
       } catch (error) {
         console.error("이달의 추천 와인 데이터를 불러오는 중 오류 발생:", error);
       }
@@ -55,16 +56,31 @@ const MonthlyWineCarousel: React.FC = () => {
       </button>
 
       <div ref={carouselRef} className={styles.carousel_container}>
-        {monthlyWines.map((wine) => (
-          <div key={wine.id} className={styles.carousel_card}>
-            <img src={wine.image} alt={wine.name} className={styles.wine_image} />
-            <div className={styles.wine_info}>
-              <h3 className={styles.wine_rating}>{wine.avgRating.toFixed(1)}</h3>
-              <p className={styles.wine_name}>{wine.name}</p>
-              <p className={styles.wine_type}>({wine.type})</p>
+        {monthlyWines.length > 0 ? (
+          monthlyWines.map((wine) => (
+            <div key={wine.id} className={styles.carousel_card}>
+              <img src={wine.image} alt={wine.name} className={styles.wine_image} />
+              <div className={styles.wine_info}>
+                <h3 className={styles.wine_rating}>{wine.avgRating.toFixed(1)}</h3>
+                <div className={styles.stars}>
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <FaStar
+                      key={star}
+                      className={wine.avgRating >= star ? styles.star_filled : styles.star_empty}
+                      size={18}
+                    />
+                  ))}
+                </div>
+                <div className={styles.wine_details}>
+                  <p className={styles.name}>{wine.name}</p>
+                  <p className={styles.wine_type}>({wine.type})</p>
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          ))
+        ) : (
+          <p className={styles.no_wines_message}>추천 와인이 없습니다.</p>
+        )}
       </div>
 
       <button className={styles.arrow_button_right} onClick={scrollRight}>

--- a/src/pages/wines/indexcomponents/SmallWineCard.module.css
+++ b/src/pages/wines/indexcomponents/SmallWineCard.module.css
@@ -3,7 +3,7 @@
 .wine_card {
   background: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);  /* 그림자 효과 강화 */
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 15px;
   text-align: center;
   width: 200px;
@@ -17,29 +17,49 @@
 }
 
 .rating {
-  font-size: 22px;  /* 평점 크기 살짝 줄임 */
+  font-size: 22px;
   font-weight: bold;
   color: #2d3034;
-  margin-top: 8px;  /* 위쪽 간격 줄임 */
+  margin-top: 8px;
 }
 
 .stars {
   display: flex;
   justify-content: center;
-  margin: 4px 0;  /* 별점 위아래 간격 조정 */
+  margin: 4px 0;
 }
 
 .star_filled {
-  color: #6a42db;
+  color: #6a42db;  /* 보라색 별 색상 */
+  border-radius: 4px;  /* 별 아이콘 모서리 둥글게 */
+  padding: 2px;  /* 별 내부 여백 추가 */
+  background-color: rgba(106, 66, 219, 0.1);  /* 연한 보라색 배경 추가 */
 }
 
 .star_empty {
   color: #e0e0e0;
+  border-radius: 4px;
+  padding: 2px;
+}
+
+.name_container {
+  min-height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .name {
-  font-size: 14px;  /* 시안에 맞춰 폰트 크기 조정 */
-  color: #2d3034;
-  margin-top: 8px;  /* 간격 조정 */
+  font-size: 14px;
+  color: #9FACBD;
   line-height: 1.4;
+  text-align: center;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.wine_origin {
+  font-size: 12px;
+  color: #9FACBD;
+  margin-top: 4px;
 }

--- a/src/pages/wines/indexcomponents/SmallWineCard.tsx
+++ b/src/pages/wines/indexcomponents/SmallWineCard.tsx
@@ -1,45 +1,33 @@
 import React from "react";
-import Image from "next/image";
+import { FaStar } from "react-icons/fa";  // react-icons에서 별 아이콘 가져오기
 import styles from "./SmallWineCard.module.css";
-import { FaStar } from "react-icons/fa";
 
 interface SmallWineCardProps {
   name: string;
-  rating: number;
+  origin: string;
   image: string;
+  rating: number;
 }
 
-const SmallWineCard: React.FC<SmallWineCardProps> = ({ name, rating, image }) => {
+const SmallWineCard: React.FC<SmallWineCardProps> = ({ name, origin, image, rating }) => {
   return (
-    <div className={styles.wine_card} style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '28px', position: 'relative', left: '12.93%', right: '12.93%', top: '12.97%', bottom: '0%' }}>
-      <div style={{ position: 'relative', width: '44px', height: '161px' }}>
-        <Image 
-          src={image} 
-          alt={name} 
-          className={styles.wine_image}
-          layout="fill"
-          objectFit="cover"
-          style={{ position: 'absolute', left: '0%', right: '0%', top: '0%', bottom: '-9.85%' }}
-        />
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: '5px', width: '100px', height: '125px' }}>
-        <div style={{ width: '57px', height: '43px', fontFamily: 'Pretendard', fontStyle: 'normal', fontWeight: 800, fontSize: '36px', lineHeight: '43px', color: '#2D3034' }}>{rating.toFixed(1)}</div>
-        <div style={{ position: 'relative', width: '90px', height: '18px' }}>
-          {Array.from({ length: 5 }, (_, i) => (
-            <FaStar 
-              key={i} 
-              style={{ 
-                position: 'absolute', 
-                width: '18px', 
-                height: '18px', 
-                left: `${i * 18}px`, 
-                top: '0px', 
-                color: i < Math.floor(rating) ? '#6A42DB' : '#CFDBEA' 
-              }} 
+    <div className={styles.wine_card}>
+      <img src={image} alt={name} className={styles.wine_image} />
+      <div className={styles.card_info}>
+        <div className={styles.name_container}>
+          <p className={styles.name}>{name}</p>
+        </div>
+        <p className={styles.wine_origin}>{origin}</p>
+        <div className={styles.stars}>
+          {[1, 2, 3, 4, 5].map((star) => (
+            <FaStar
+              key={star}
+              className={rating >= star ? styles.star_filled : styles.star_empty}
+              size={18}  // 아이콘 크기 설정
             />
           ))}
         </div>
-        <div style={{ width: '100px', height: '54px', fontFamily: 'Pretendard', fontStyle: 'normal', fontWeight: 400, fontSize: '12px', lineHeight: '18px', color: '#9FACBD' }}>{name}</div>
+        <div className={styles.rating}>{rating}/5</div>
       </div>
     </div>
   );

--- a/src/pages/wines/indexcomponents/WineCard.module.css
+++ b/src/pages/wines/indexcomponents/WineCard.module.css
@@ -31,7 +31,8 @@
 
 .info_section {
   flex-grow: 1;
-  margin-left: 20px;
+  margin-left: 50px;
+  width: 400px;
 }
 
 .name {
@@ -53,16 +54,17 @@
   border-radius: 8px;
   padding: 5px 10px;
   font-size: 16px;
+  font-weight: 700;
   margin-top: 10px;
   display: inline-block;
 }
 
 .rating_section {
-  text-align: right;
+  text-align: left;
 }
 
 .rating {
-  font-size: 28px;  /* 평점 숫자 크기 줄임 */
+  font-size: 40px;
   font-weight: bold;
   color: #2d3034;
 }
@@ -91,14 +93,15 @@
 
 .arrow_icon {
   color: #9facbd;
-  font-size: 16px;
+  font-size: 23px;
   margin-top: 10px;
+  text-align: right;
 }
 
 .latest_review_section {
   border-top: 1px solid #e0e0e0;
   padding-top: 15px;
-  margin-top: 15px;
+  margin: 15px 30px 0px;
 }
 
 .latest_review_section h3 {

--- a/src/pages/wines/indexcomponents/WineCard.tsx
+++ b/src/pages/wines/indexcomponents/WineCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useRouter } from "next/router";
-import Image from "next/image";
 import styles from "./WineCard.module.css";
 import { FaStar, FaArrowRight } from "react-icons/fa";
 
@@ -12,7 +11,7 @@ interface WineCardProps {
   region: string;
   price: number;
   reviewCount: number;
-  recentReview?: { content: string } | null; // null 허용 추가
+  recentReview?: { content: string } | null;
 }
 
 const WineCard: React.FC<WineCardProps> = ({
@@ -27,7 +26,13 @@ const WineCard: React.FC<WineCardProps> = ({
   return (
     <div className={styles.wine_card} onClick={handleCardClick}>
       <div className={styles.card_top}>
-        <Image src={image} alt={name} className={styles.wine_image} width={100} height={150} />
+        <img 
+        src={image || "https://via.placeholder.com/150"} 
+        alt={name} 
+        className={styles.wine_image}
+        style={{ width: '150px', height: '200px', objectFit: 'cover', borderRadius: '8px' }}
+        />
+
 
         <div className={styles.info_section}>
           <h2 className={styles.name}>{name}</h2>
@@ -36,9 +41,7 @@ const WineCard: React.FC<WineCardProps> = ({
         </div>
 
         <div className={styles.rating_section}>
-          <div className={styles.rating}>
-            {avgRating.toFixed(1)}
-          </div>
+          <div className={styles.rating}>{avgRating.toFixed(1)}</div>
           <div className={styles.stars}>
             {Array.from({ length: 5 }, (_, i) => (
               <FaStar key={i} className={i < Math.floor(avgRating) ? styles.star_filled : styles.star_empty} />

--- a/src/pages/wines/indexcomponents/WineFilter.module.css
+++ b/src/pages/wines/indexcomponents/WineFilter.module.css
@@ -53,9 +53,9 @@
 
 .range_slider_container {
   position: relative;
-  width: 90%; /* 슬라이더 너비를 줄여 필터 박스 안에 맞게 조정 */
+  width: 90%;
   height: 8px;
-  margin: 0 auto 20px auto; /* 중앙 정렬 */
+  margin: 0 auto 20px auto;
 }
 
 .range_slider {

--- a/src/pages/wines/indexcomponents/WineFilter.tsx
+++ b/src/pages/wines/indexcomponents/WineFilter.tsx
@@ -7,17 +7,17 @@ interface WineFilterProps {
     minPrice: number;
     maxPrice: number;
     ratings: string[];
-  }) => void;
+  } | null) => void; // 필터가 없을 경우 null 전달
 }
 
 const WineFilter: React.FC<WineFilterProps> = ({ onApplyFilters }) => {
-  const [selectedType, setSelectedType] = useState<string>('White');
+  const [selectedType, setSelectedType] = useState<string | null>(null);
   const [minPrice, setMinPrice] = useState<number>(0);
   const [maxPrice, setMaxPrice] = useState<number>(5000000);
   const [selectedRatings, setSelectedRatings] = useState<string[]>([]);
 
   const handleTypeClick = (type: string) => {
-    setSelectedType(type);
+    setSelectedType(prevType => (prevType === type ? null : type));
   };
 
   const handleMinPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,15 +44,19 @@ const WineFilter: React.FC<WineFilterProps> = ({ onApplyFilters }) => {
 
   const handleApplyFilters = () => {
     if (onApplyFilters) {
-      onApplyFilters({
-        type: selectedType,
-        minPrice,
-        maxPrice,
-        ratings: selectedRatings,
-      });
+      // 모든 필터가 초기 상태일 경우 null 전달
+      if (!selectedType && minPrice === 0 && maxPrice === 5000000 && selectedRatings.length === 0) {
+        onApplyFilters(null);
+      } else {
+        onApplyFilters({
+          type: selectedType || '',
+          minPrice,
+          maxPrice,
+          ratings: selectedRatings,
+        });
+      }
     }
   };
-  
 
   return (
     <div className={styles.filter_container}>

--- a/src/pages/wines/indexcomponents/WinePage.module.css
+++ b/src/pages/wines/indexcomponents/WinePage.module.css
@@ -127,3 +127,25 @@
     justify-content: center;
   }
 } 
+
+.load_more_button {
+  background-color: #6a42db;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-size: 16px;
+  cursor: pointer;
+  margin: 20px auto;
+  display: block;
+  transition: background 0.3s;
+}
+
+.load_more_button:hover {
+  background-color: #5a36b5;
+}
+
+.load_more_button:disabled {
+  background-color: #d3d3d3;
+  cursor: not-allowed;
+}

--- a/src/pages/wines/indexcomponents/WineRegisterModal.module.css
+++ b/src/pages/wines/indexcomponents/WineRegisterModal.module.css
@@ -176,3 +176,87 @@
   background: #F1EDFC;
   color: #6A42DB;
 }
+
+.image_preview_container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.image_preview {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid #CFDBEA;
+}
+
+.modal_container_wide {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 24px;
+  gap: 40px;
+  position: absolute;
+  width: 600px;  /* 기존 460px에서 600px로 너비 증가 */
+  max-height: 90vh;  /* 화면의 90% 높이로 제한 */
+  background: #FFFFFF;
+  border-radius: 16px;
+  overflow: hidden;  /* 좌우 스크롤 방지 */
+}
+
+.modal_body_scrollable {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 32px;
+  width: 100%;
+  overflow-y: auto;  /* 세로 스크롤 활성화 */
+  overflow-x: hidden;  /* 좌우 스크롤 제거 */
+  max-height: 600px;
+}
+
+.modal_body_scrollable::-webkit-scrollbar {
+  width: 8px;
+}
+
+.modal_body_scrollable::-webkit-scrollbar-thumb {
+  background-color: #6a42db;
+  border-radius: 4px;
+}
+
+.modal_body_scrollable::-webkit-scrollbar-track {
+  background-color: #f1f1f1;
+}
+
+.remove_image_button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: #ff4d4f;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.3s;
+}
+
+.remove_image_button:hover {
+  background: #d9363e;
+}
+
+.image_preview_container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+}

--- a/src/pages/wines/indexcomponents/WineRegisterModal.tsx
+++ b/src/pages/wines/indexcomponents/WineRegisterModal.tsx
@@ -7,6 +7,7 @@ interface WineData {
   origin: string;
   type: string;
   rating: number;
+  image: string;
 }
 
 interface WineRegisterModalProps {
@@ -20,6 +21,7 @@ const WineRegisterModal: React.FC<WineRegisterModalProps> = ({ onClose, onSubmit
   const [origin, setOrigin] = useState("");
   const [type, setType] = useState("RED");
   const [rating, setRating] = useState(0);
+  const [image, setImage] = useState<string>("");
 
   const handleRegister = () => {
     const numericPrice = parseFloat(price);
@@ -34,8 +36,10 @@ const WineRegisterModal: React.FC<WineRegisterModalProps> = ({ onClose, onSubmit
       origin,
       type,
       rating,
+      image: image || "https://via.placeholder.com/150",
     };
 
+    console.log("등록할 와인 데이터:", wineData);
     onSubmit(wineData);
   };
 
@@ -47,7 +51,7 @@ const WineRegisterModal: React.FC<WineRegisterModalProps> = ({ onClose, onSubmit
           <button className={styles.close_button} onClick={onClose}>×</button>
         </div>
 
-        <div className={styles.modal_body}>
+        <div className={styles.modal_body_scrollable}>
           <label className={styles.label}>와인 이름</label>
           <input 
             type="text"
@@ -60,7 +64,7 @@ const WineRegisterModal: React.FC<WineRegisterModalProps> = ({ onClose, onSubmit
 
           <label className={styles.label}>가격</label>
           <input 
-            type="text"  // 숫자 스핀 버튼 제거
+            type="text"
             className={styles.input}
             placeholder="가격 입력"
             value={price}
@@ -101,6 +105,22 @@ const WineRegisterModal: React.FC<WineRegisterModalProps> = ({ onClose, onSubmit
               </span>
             ))}
           </div>
+
+          <label className={styles.label}>이미지 URL</label>
+          <input 
+            type="text"
+            className={styles.input}
+            placeholder="이미지 URL 입력"
+            value={image}
+            onChange={(e) => setImage(e.target.value)}
+          />
+
+          {image && (
+            <div className={styles.image_preview_container}>
+              <img src={image} alt="미리보기" className={styles.image_preview} />
+              <button className={styles.remove_image_button} onClick={() => setImage("")}>×</button>
+            </div>
+          )}
 
           <button 
             className={styles.register_button}


### PR DESCRIPTION
## 작업 내용

### 1. 페이지네이션 구현을 통한 와인데이터 모두 불러오기.
1-1. 더보기 버튼 누르면 나머지 와인 보여주는 기능 구현.

### 2. 와인등록모달창에 이미지 URL추가 기능 구현
- 친숙한 이미지업로드형식으로 했을 때 이미지파일크기가 너무 커서 렌더링되지 않는 현상 때문에 구글 등의 사이트에서 주소복사를 통해 업로드하는 형식 채택함.
2-1. 와인목록페이지 와인카드에 이미지가 보이지 않는 현상 수정

### 3. 이달추천와인카드 내부에 별점디자인 추가.
3-1. 이달추천와인카드 이름이 길면 스크롤하게끔 수정.

### 4. 메인와인카드 텍스트 크기 및 굵기 조절.

### 5. 와인필터에서 타입버튼을 아무것도 선택하지 않으면 모든 와인카드가 나오게끔 수정.